### PR TITLE
Handle cases where remote resources have been deleted

### DIFF
--- a/docs/resources/compute_environment.md
+++ b/docs/resources/compute_environment.md
@@ -63,7 +63,7 @@ resource "nftower_compute_environment" "example-awsbatch" {
 - `date_created` (String) The datetime the workspace was created.
 - `id` (String) The ID of this resource.
 - `last_updated` (String) The last updated datetime of the workspace.
-- `status` (String) The status of the workspace. Can be CREATING, AVAILABLE or ERRORED.
+- `status` (String) The status of the workspace. Can be CREATING, AVAILABLE, ERRORED or INVALID.
 
 <a id="nestedblock--aws_batch"></a>
 ### Nested Schema for `aws_batch`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -187,7 +187,7 @@ func (c *TowerClient) request(ctx context.Context, method string, path string, q
 	}
 
 	if httpResp.StatusCode > 399 {
-		return nil, fmt.Errorf("Tower API returned status: %s %s %s", httpResp.Status, httpResp.Request.URL, string(body))
+		return nil, newTowerError(fmt.Errorf("Tower API returned status: %s %s %s", httpResp.Status, httpResp.Request.URL, string(body)), httpResp.StatusCode)
 	}
 
 	if body == nil || len(body) == 0 {

--- a/internal/client/compute_envs.go
+++ b/internal/client/compute_envs.go
@@ -78,6 +78,10 @@ func (c *TowerClient) GetComputeEnv(ctx context.Context, workspaceId string, id 
 	computeEnvObj := res.(map[string]interface{})
 	computeEnv := computeEnvObj["computeEnv"].(map[string]interface{})
 
+	if computeEnv["deleted"].(bool) {
+		return nil, nil
+	}
+
 	switch computeEnv["platform"].(string) {
 	case "aws-batch":
 		config, err := unmarshalComputeEnvAWSBatchConfig(computeEnv["config"].(map[string]interface{}))

--- a/internal/client/credentials.go
+++ b/internal/client/credentials.go
@@ -94,6 +94,13 @@ func (c *TowerClient) GetCredentials(ctx context.Context, workspaceId string, id
 	res, err := c.requestWithoutPayload(ctx, "GET", fmt.Sprintf("/credentials/%s", id), map[string]string{"workspaceId": workspaceId})
 
 	if err != nil {
+		if v, ok := err.(towerError); ok {
+			if v.statusCode == 403 {
+				// when the remote credentials have been deleted,
+				// tower returns a 403 instead of a 404 :(
+				return nil, nil
+			}
+		}
 		return nil, err
 	}
 

--- a/internal/client/datasets.go
+++ b/internal/client/datasets.go
@@ -31,8 +31,19 @@ func (c *TowerClient) GetDataset(ctx context.Context, workspaceId string, id str
 		return nil, err
 	}
 
+	if res == nil {
+		return nil, nil
+	}
+
 	datasetObj := res.(map[string]interface{})
-	return datasetObj["dataset"].(map[string]interface{}), nil
+
+	dataset := datasetObj["dataset"].(map[string]interface{})
+
+	if dataset["deleted"].(bool) {
+		return nil, nil
+	}
+
+	return dataset, nil
 }
 
 func (c *TowerClient) UpdateDataset(ctx context.Context, workspaceId string, id string, name string, description string) error {

--- a/internal/client/org_members.go
+++ b/internal/client/org_members.go
@@ -50,7 +50,7 @@ func (c *TowerClient) GetOrganizationMember(ctx context.Context, email string) (
 	members := res.(map[string]interface{})
 
 	if int64(members["totalSize"].(float64)) == 0 {
-		return nil, fmt.Errorf("Could not find a member with email %s", email)
+		return nil, nil
 	}
 
 	member := members["members"].([]interface{})

--- a/internal/client/tokens.go
+++ b/internal/client/tokens.go
@@ -41,7 +41,7 @@ func (c *TowerClient) GetToken(ctx context.Context, id string) (map[string]inter
 		}
 	}
 
-	return nil, fmt.Errorf("Could not find token with id %s", id)
+	return nil, nil
 }
 
 func (c *TowerClient) DeleteToken(ctx context.Context, id string) error {

--- a/internal/client/tower_error.go
+++ b/internal/client/tower_error.go
@@ -1,0 +1,17 @@
+package client
+
+type towerError struct {
+	err        error
+	statusCode int
+}
+
+func (e towerError) Error() string {
+	return e.err.Error()
+}
+
+func newTowerError(err error, statusCode int) towerError {
+	return towerError{
+		err:        err,
+		statusCode: statusCode,
+	}
+}

--- a/internal/client/workspace_participants.go
+++ b/internal/client/workspace_participants.go
@@ -50,7 +50,7 @@ func (c *TowerClient) GetWorkspaceParticipant(ctx context.Context, workspaceId s
 	participants := res.(map[string]interface{})
 
 	if int64(participants["totalSize"].(float64)) == 0 {
-		return nil, fmt.Errorf("Could not find a member with email %s", email)
+		return nil, nil
 	}
 
 	participant := participants["participants"].([]interface{})

--- a/internal/client/workspaces.go
+++ b/internal/client/workspaces.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 func (c *TowerClient) CreateWorkspace(ctx context.Context, name string, fullName string, description string, visibility string) (int64, error) {
@@ -39,9 +40,14 @@ func (c *TowerClient) GetWorkspace(ctx context.Context, id int64) (map[string]in
 		return nil, err
 	}
 
-	workspace := res.(map[string]interface{})
+	workspaceObj := res.(map[string]interface{})
+	workspace := workspaceObj["workspace"].(map[string]interface{})
 
-	return workspace["workspace"].(map[string]interface{}), nil
+	if strings.HasPrefix(workspace["name"].(string), "deleted-"){
+		return nil, nil
+	}
+
+	return workspace, nil
 }
 
 func (c *TowerClient) GetWorkspaceByName(ctx context.Context, name string) (map[string]interface{}, error) {

--- a/internal/provider/data_source_compute_env.go
+++ b/internal/provider/data_source_compute_env.go
@@ -2,9 +2,6 @@ package provider
 
 import (
 	"context"
-	"fmt"
-
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/healx/terraform-provider-nftower/internal/client"
@@ -155,10 +152,12 @@ func dataSourceComputeEnvRead(ctx context.Context, d *schema.ResourceData, meta 
 
 	computeEnv, err := towerClient.GetComputeEnvByName(ctx, d.Get("workspace_id").(string), d.Get("name").(string))
 
-	tflog.Trace(ctx, fmt.Sprintf("computeEnv: %v", computeEnv))
-
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	if computeEnv == nil {
+		return diag.Errorf("unable to find compute environment with name: %s", d.Get("name").(string))
 	}
 
 	d.SetId(computeEnv["id"].(string))

--- a/internal/provider/data_source_credentials.go
+++ b/internal/provider/data_source_credentials.go
@@ -92,6 +92,10 @@ func dataSourceCredentialsRead(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
+	if credentials == nil {
+		return diag.Errorf("unable to find credentials with name: %s", d.Get("name").(string))
+	}
+
 	d.SetId(credentials["id"].(string))
 	d.Set("name", credentials["name"].(string))
 	d.Set("description", credentials["description"].(string))

--- a/internal/provider/data_source_organization_member.go
+++ b/internal/provider/data_source_organization_member.go
@@ -48,13 +48,16 @@ func dataSourceOrganizationMember() *schema.Resource {
 
 func dataSourceOrganizationMemberRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*client.TowerClient)
-
-	member, err := client.GetOrganizationMember(
-		ctx,
-		d.Get("email").(string))
+	
+	email := d.Get("email").(string)
+	member, err := client.GetOrganizationMember(ctx, email)
 
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	if member == nil {
+		return diag.Errorf("unable to find member with email: %s", email)
 	}
 
 	d.SetId(fmt.Sprintf("%d", int64(member["memberId"].(float64))))

--- a/internal/provider/data_source_workspace.go
+++ b/internal/provider/data_source_workspace.go
@@ -60,6 +60,10 @@ func dataSourceWorkspaceRead(ctx context.Context, d *schema.ResourceData, meta a
 		return diag.FromErr(err)
 	}
 
+	if workspace == nil {
+		return diag.Errorf("unable to find workspace with name: %s", d.Get("name").(string))
+	}
+
 	d.SetId(fmt.Sprintf("%d", int64(workspace["id"].(float64))))
 
 	d.Set("name", workspace["name"].(string))

--- a/internal/provider/data_source_workspace_participant.go
+++ b/internal/provider/data_source_workspace_participant.go
@@ -54,13 +54,18 @@ func dataSourceWorkspaceParticipant() *schema.Resource {
 func dataSourceWorkspaceParticipantRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*client.TowerClient)
 
+	email := d.Get("email").(string)
 	participant, err := client.GetWorkspaceParticipant(
 		ctx,
 		d.Get("workspace_id").(string),
-		d.Get("email").(string))
+		email)
 
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	if participant == nil {
+		return diag.Errorf("unable to find participant with email: %s", email)
 	}
 
 	d.SetId(fmt.Sprintf("%d", int64(participant["participantId"].(float64))))

--- a/internal/provider/resource_action.go
+++ b/internal/provider/resource_action.go
@@ -185,6 +185,11 @@ func resourceActionRead(ctx context.Context, d *schema.ResourceData, meta any) d
 		return diag.FromErr(err)
 	}
 
+	if action == nil {
+		d.SetId("")
+		return nil
+	}
+
 	d.Set("name", action["name"].(string))
 	d.Set("source", action["source"].(string))
 	d.Set("status", action["status"].(string))

--- a/internal/provider/resource_compute_environment.go
+++ b/internal/provider/resource_compute_environment.go
@@ -45,7 +45,7 @@ func resourceComputeEnvironment() *schema.Resource {
 				ForceNew:    true,
 			},
 			"status": {
-				Description: "The status of the workspace. Can be CREATING, AVAILABLE or ERRORED.",
+				Description: "The status of the workspace. Can be CREATING, AVAILABLE, ERRORED or INVALID.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
@@ -208,6 +208,11 @@ func resourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData,
 
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	if computeEnv == nil {
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("name", computeEnv["name"].(string))

--- a/internal/provider/resource_credentials.go
+++ b/internal/provider/resource_credentials.go
@@ -153,6 +153,11 @@ func resourceCredentialsRead(ctx context.Context, d *schema.ResourceData, meta a
 		return diag.FromErr(err)
 	}
 
+	if credentials == nil {
+		d.SetId("")
+		return nil
+	}
+
 	d.Set("name", credentials["name"].(string))
 	d.Set("description", credentials["description"].(string))
 	d.Set("date_created", credentials["dateCreated"].(string))

--- a/internal/provider/resource_dataset.go
+++ b/internal/provider/resource_dataset.go
@@ -79,6 +79,11 @@ func resourceDatasetRead(ctx context.Context, d *schema.ResourceData, meta any) 
 		return diag.FromErr(err)
 	}
 
+	if dataset == nil {
+		d.SetId("")
+		return nil
+	}
+
 	d.Set("name", dataset["name"].(string))
 
 	if description, ok := dataset["description"].(string); ok {

--- a/internal/provider/resource_organization_member.go
+++ b/internal/provider/resource_organization_member.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/healx/terraform-provider-nftower/internal/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/healx/terraform-provider-nftower/internal/client"
 )
 
 func resourceOrganizationMember() *schema.Resource {
@@ -29,10 +28,10 @@ func resourceOrganizationMember() *schema.Resource {
 				ForceNew:    true,
 			},
 			"role": {
-				Description: "The role of the member. Can be owner or member",
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "member",
+				Description:  "The role of the member. Can be owner or member",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "member",
 				ValidateFunc: validation.StringInSlice([]string{"member", "owner"}, false),
 			},
 			"first_name": {
@@ -81,7 +80,10 @@ func resourceOrganizationMemberRead(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	tflog.Trace(ctx, "reading new member", member)
+	if member == nil {
+		d.SetId("")
+		return nil
+	}
 
 	d.Set("email", member["email"].(string))
 	d.Set("user_name", member["userName"].(string))

--- a/internal/provider/resource_token.go
+++ b/internal/provider/resource_token.go
@@ -61,6 +61,11 @@ func resourceTokenRead(ctx context.Context, d *schema.ResourceData, meta any) di
 		return diag.FromErr(err)
 	}
 
+	if token == nil {
+		d.SetId("")
+		return nil
+	}
+
 	d.Set("name", token["name"].(string))
 	d.Set("date_created", token["dateCreated"].(string))
 

--- a/internal/provider/resource_workspace.go
+++ b/internal/provider/resource_workspace.go
@@ -91,6 +91,11 @@ func resourceWorkspaceRead(ctx context.Context, d *schema.ResourceData, meta any
 		return diag.FromErr(err)
 	}
 
+	if workspace == nil {
+		d.SetId("")
+		return nil
+	}
+
 	d.Set("name", workspace["name"].(string))
 	d.Set("full_name", workspace["fullName"].(string))
 

--- a/internal/provider/resource_workspace_participant.go
+++ b/internal/provider/resource_workspace_participant.go
@@ -124,6 +124,11 @@ func resourceWorkspaceParticipantRead(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
+	if participant == nil {
+		d.SetId("")
+		return nil
+	}
+
 	if v, ok := participant["firstName"].(string); ok {
 		d.Set("first_name", v)
 	}


### PR DESCRIPTION
Previously the `Get<X>(...)` client methods have been returning an error when the remote resource doesn't exist, however this means that when a remote resource has been deleted, 
terraform will error out and require manual state intervention. The desired behaviour is for terraform to simply recreate the remote resource.

There are a few different patterns implemented in the api, some resources (like credentials) will return a 403 when they have been deleted. Others return a resource with the `deleted: 
true` parameter set in the body. The final one I have observed (e.g. for workspaces) is that the workspace name will be changed to `deleted-<workspace_id>`.

