### PR TITLE
Add an error message if a participant isn't found

### DIFF
--- a/internal/provider/resource_workspace_participant.go
+++ b/internal/provider/resource_workspace_participant.go
@@ -88,6 +88,10 @@ func resourceWorkspaceParticipantCreate(ctx context.Context, d *schema.ResourceD
 			return diag.FromErr(err)
 		}
 
+		if member == nil {
+			return diag.Errorf("no member found in organization with email %s", email)
+		}
+
 		memberId = int64(member["memberId"].(float64))
 	}
 


### PR DESCRIPTION
I do not know quite enough Go or Terraform provider work to know if this is actually correct, but hopefully it'll fix the problem where there's no clear message if a participant isn't found in the organization.