### PR TITLE
fix: various bugfixes

### DIFF
--- a/docs/data-sources/credentials.md
+++ b/docs/data-sources/credentials.md
@@ -37,6 +37,7 @@ data "nftower_credentials" "foo" {
 - `date_created` (String) The datetime the credentials were created.
 - `description` (String) The description of the environment.
 - `github` (List of Object) Stores a github access token. (see [below for nested schema](#nestedatt--github))
+- `gitlab` (List of Object) Stores a gitlab access token. (see [below for nested schema](#nestedatt--gitlab))
 - `id` (String) The ID of this resource.
 - `last_updated` (String) The last updated datetime of the credentials.
 
@@ -51,6 +52,15 @@ Read-Only:
 
 <a id="nestedatt--github"></a>
 ### Nested Schema for `github`
+
+Read-Only:
+
+- `base_url` (String)
+- `username` (String)
+
+
+<a id="nestedatt--gitlab"></a>
+### Nested Schema for `gitlab`
 
 Read-Only:
 

--- a/docs/resources/compute_environment.md
+++ b/docs/resources/compute_environment.md
@@ -32,7 +32,7 @@ resource "nftower_credentials" "aws" {
 resource "nftower_compute_environment" "example-awsbatch" {
   name           = "example-awsbatch"
   workspace_id   = nftower_workspace.example.id
-  credentials_id = nftower_workspace.aws.id
+  credentials_id = nftower_credentials.aws.id
 
   aws_batch {
     region        = "eu-west-1"
@@ -42,10 +42,19 @@ resource "nftower_compute_environment" "example-awsbatch" {
   }
 }
 
+resource "nftower_credentials" "lsf_submission_ssh_key" {
+  name         = "lsf-submission-ssh-key"
+  workspace_id = nftower_workspace.example.id
+
+  ssh {
+    private_key = "private key"
+  }
+}
+
 resource "nftower_compute_environment" "example-lsfplatform" {
   name           = "example-lsfplatform"
   workspace_id   = nftower_workspace.example.id
-  credentials_id = nftower_workspace.aws.id
+  credentials_id = nftower_credentials.lsf_submission_ssh_key.id
 
   lsf_platform {
     work_dir      = "s3://my-nf-workdir"
@@ -69,6 +78,7 @@ resource "nftower_compute_environment" "example-lsfplatform" {
 - `aws_batch` (Block List, Max: 1) Configures an AWS Batch compute environment (manual only). (see [below for nested schema](#nestedblock--aws_batch))
 - `description` (String) The description of the environment.
 - `environment_variable` (Block List) A List of environment variables that can be included for head or compute jobs. (see [below for nested schema](#nestedblock--environment_variable))
+- `lsf_platform` (Block List, Max: 1) Configures an IBM LSF compute environment. (see [below for nested schema](#nestedblock--lsf_platform))
 
 ### Read-Only
 
@@ -107,3 +117,28 @@ Required:
 - `name` (String) The name of the environment variable must contain only alphanumeric, dash and underscore characters, and cannot begin with a number.
 - `value` (String) The value of the environment variable.
 - `visibility` (String) Which jobs this environment variable should be available to, can be HEAD, COMPUTE or BOTH.
+
+
+<a id="nestedblock--lsf_platform"></a>
+### Nested Schema for `lsf_platform`
+
+Required:
+
+- `compute_queue` (String) The default LSF queue to which Nextflow will submit job executions. This can be overwritten via the usual Nextflow config.
+- `head_job_options` (String) options to add to BSUB when submitting the head job.
+- `head_queue` (String) The LSF queue that will run the Nextflow application. A queue that does not use spot instances is expected.
+- `host_name` (String) hostname of the login node for your IBM LSF cluster.
+- `launch_dir` (String) The directory where tower will launch workflows.
+- `per_job_mem_limit` (Boolean) Enable per-job mem limits.
+- `per_task_reserve` (Boolean) Enable per task reserve.
+- `propagate_head_job_options` (Boolean) Whether to propagate the head job optoins to spawned worker jobs or not.
+- `user_name` (String) IBM LSF username to use.
+- `work_dir` (String) The nextflow work directory.
+
+Optional:
+
+- `max_queue_size` (Number) Max size of queue.
+- `port` (Number) The port for ssh connection.
+- `post_run_script` (String) script to run on submission node after running nextflow.
+- `pre_run_script` (String) script to run on submission node before running nextflow.
+- `unit_for_limits` (String) the unit to use for limits.

--- a/docs/resources/credentials.md
+++ b/docs/resources/credentials.md
@@ -52,6 +52,8 @@ resource "nftower_credentials" "github" {
 - `aws` (Block List, Max: 1) Stores an AWS IAM access key. (see [below for nested schema](#nestedblock--aws))
 - `description` (String) The description of the credentials.
 - `github` (Block List, Max: 1) Stores a github access token. (see [below for nested schema](#nestedblock--github))
+- `gitlab` (Block List, Max: 1) Stores a gitlab access token. (see [below for nested schema](#nestedblock--gitlab))
+- `ssh` (Block List, Max: 1) Stores an SSH private key. (see [below for nested schema](#nestedblock--ssh))
 
 ### Read-Only
 
@@ -83,3 +85,29 @@ Required:
 Optional:
 
 - `base_url` (String) The base url when connecting to github. Used for github enterprise on-prem.
+
+
+<a id="nestedblock--gitlab"></a>
+### Nested Schema for `gitlab`
+
+Required:
+
+- `password` (String, Sensitive) The personal access token to use to connect to gitlab.
+- `token` (String, Sensitive) The personal access token to use to connect to gitlab.
+- `username` (String) The name of the user that the token belongs.
+
+Optional:
+
+- `base_url` (String) The base url when connecting to github. Used for github enterprise on-prem.
+
+
+<a id="nestedblock--ssh"></a>
+### Nested Schema for `ssh`
+
+Required:
+
+- `private_key` (String, Sensitive) The SSH private key.
+
+Optional:
+
+- `passphrase` (String, Sensitive) The passphrase for the SSH private key.

--- a/examples/resources/nftower_compute_environment/resource.tf
+++ b/examples/resources/nftower_compute_environment/resource.tf
@@ -17,7 +17,7 @@ resource "nftower_credentials" "aws" {
 resource "nftower_compute_environment" "example-awsbatch" {
   name           = "example-awsbatch"
   workspace_id   = nftower_workspace.example.id
-  credentials_id = nftower_workspace.aws.id
+  credentials_id = nftower_credentials.aws.id
 
   aws_batch {
     region        = "eu-west-1"
@@ -27,10 +27,19 @@ resource "nftower_compute_environment" "example-awsbatch" {
   }
 }
 
+resource "nftower_credentials" "lsf_submission_ssh_key" {
+  name         = "lsf-submission-ssh-key"
+  workspace_id = nftower_workspace.example.id
+
+  ssh {
+    private_key = "private key"
+  }
+}
+
 resource "nftower_compute_environment" "example-lsfplatform" {
   name           = "example-lsfplatform"
   workspace_id   = nftower_workspace.example.id
-  credentials_id = nftower_workspace.aws.id
+  credentials_id = nftower_credentials.lsf_submission_ssh_key.id
 
   lsf_platform {
     work_dir      = "s3://my-nf-workdir"

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -176,13 +176,26 @@ func (c *TowerClient) request(ctx context.Context, method string, path string, q
 
 	tflog.Trace(ctx, fmt.Sprintf("header: Content-Type: %s", req.Header.Get("Content-Type")))
 
+	fmt.Println("=== request ===")
+	fmt.Println("method: ", method)
+	fmt.Println("url: ", c.apiUrl.ResolveReference(&url.URL{Path: c.apiUrl.JoinPath(path).Path, RawQuery: querystring}).String())
+	fmt.Println("headers: ", formatHeaders(req.Header))
+	fmt.Println("request payload: ", payload)
+
 	httpResp, err := c.http.Do(req)
 	if err != nil {
+		fmt.Println("!!!!! FAILED !!!!!!")
+		fmt.Println("=== end request ===")
+
 		return nil, err
 	}
 
 	var resp interface{}
 	body, err := io.ReadAll(httpResp.Body)
+
+	fmt.Println("body: ", string(body))
+	fmt.Println("status: ", httpResp.Status)
+	fmt.Println("=== end request ===")
 
 	if err != nil {
 		return nil, err

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -176,26 +176,13 @@ func (c *TowerClient) request(ctx context.Context, method string, path string, q
 
 	tflog.Trace(ctx, fmt.Sprintf("header: Content-Type: %s", req.Header.Get("Content-Type")))
 
-	fmt.Println("=== request ===")
-	fmt.Println("method: ", method)
-	fmt.Println("url: ", c.apiUrl.ResolveReference(&url.URL{Path: c.apiUrl.JoinPath(path).Path, RawQuery: querystring}).String())
-	fmt.Println("headers: ", formatHeaders(req.Header))
-	fmt.Println("request payload: ", payload)
-
 	httpResp, err := c.http.Do(req)
 	if err != nil {
-		fmt.Println("!!!!! FAILED !!!!!!")
-		fmt.Println("=== end request ===")
-
 		return nil, err
 	}
 
 	var resp interface{}
 	body, err := io.ReadAll(httpResp.Body)
-
-	fmt.Println("body: ", string(body))
-	fmt.Println("status: ", httpResp.Status)
-	fmt.Println("=== end request ===")
 
 	if err != nil {
 		return nil, err

--- a/internal/client/compute_envs.go
+++ b/internal/client/compute_envs.go
@@ -63,7 +63,7 @@ func (c *TowerClient) CreateLSFPlatformComputeEnv(
 		"computeEnv": map[string]interface{}{
 			"name":          name,
 			"description":   description,
-			"platform":      "aws-batch",
+			"platform":      "lsf-platform",
 			"credentialsId": credentialsId,
 			"config":        marshalComputeEnvLSFPlatformConfig(config),
 		},

--- a/internal/client/credentials.go
+++ b/internal/client/credentials.go
@@ -55,6 +55,56 @@ func (c *TowerClient) CreateCredentialsGithub(
 	return c.createCredentials(ctx, workspaceId, payload)
 }
 
+func (c *TowerClient) CreateCredentialsGitlab(
+	ctx context.Context,
+	workspaceId string,
+	name string,
+	description string,
+	baseUrl string,
+	username string,
+	password string,
+	token string) (string, error) {
+
+	payload := map[string]interface{}{
+		"credentials": map[string]interface{}{
+			"name":        name,
+			"description": description,
+			"provider":    "gitlab",
+			"baseUrl":     baseUrl,
+			"keys": map[string]interface{}{
+				"username": username,
+				"password": password,
+				"token":    token,
+			},
+		},
+	}
+
+	return c.createCredentials(ctx, workspaceId, payload)
+}
+
+func (c *TowerClient) CreateCredentialsSSH(
+	ctx context.Context,
+	workspaceId string,
+	name string,
+	description string,
+	sshKey string,
+	sshKeyPassphrase string) (string, error) {
+
+	payload := map[string]interface{}{
+		"credentials": map[string]interface{}{
+			"name":        name,
+			"description": description,
+			"provider":    "ssh",
+			"keys": map[string]interface{}{
+				"privateKey": sshKey,
+				"passphrase": sshKeyPassphrase,
+			},
+		},
+	}
+
+	return c.createCredentials(ctx, workspaceId, payload)
+}
+
 func (c *TowerClient) createCredentials(ctx context.Context, workspaceId string, payload map[string]interface{}) (string, error) {
 	res, err := c.requestWithJsonPayload(ctx, "POST", "/credentials", map[string]string{"workspaceId": workspaceId}, payload)
 

--- a/internal/client/org_members.go
+++ b/internal/client/org_members.go
@@ -14,23 +14,22 @@ func (c *TowerClient) CreateOrganizationMember(ctx context.Context, email string
 
 	res, err := c.requestWithJsonPayload(ctx, "PUT", fmt.Sprintf("/orgs/%d/members/add", c.orgId), nil, payload)
 
-	towerErr, ok := err.(towerError)
-	if ok {
-		// If user already exists, update role
-		if towerErr.statusCode == 409 {
-			member, err = c.GetOrganizationMember(ctx, email)
-		}
-		if err != nil {
-			return -1, err
+	if err != nil {
+		towerErr, ok := err.(towerError)
+		if ok {
+			// If user already exists, update role
+			if towerErr.statusCode == 409 {
+				member, err = c.GetOrganizationMember(ctx, email)
+			}
+			if err != nil {
+				return -1, err
+			}
+		} else {
+			if res == nil {
+				return -1, fmt.Errorf("Empty response from server")
+			}
 		}
 	} else {
-		if err != nil {
-			return -1, err
-		}
-
-		if res == nil {
-			return -1, fmt.Errorf("Empty response from server")
-		}
 		memberObj := res.(map[string]interface{})
 		member = memberObj["member"].(map[string]interface{})
 	}

--- a/internal/client/org_members.go
+++ b/internal/client/org_members.go
@@ -25,11 +25,12 @@ func (c *TowerClient) CreateOrganizationMember(ctx context.Context, email string
 				return -1, err
 			}
 		} else {
-			if res == nil {
-				return -1, fmt.Errorf("Empty response from server")
-			}
+			return -1, err
 		}
 	} else {
+		if res == nil {
+			return -1, fmt.Errorf("Empty response from server")
+		}
 		memberObj := res.(map[string]interface{})
 		member = memberObj["member"].(map[string]interface{})
 	}

--- a/internal/provider/data_source_credentials.go
+++ b/internal/provider/data_source_credentials.go
@@ -79,6 +79,25 @@ func dataSourceCredentials() *schema.Resource {
 					},
 				},
 			},
+			"gitlab": {
+				Description: "Stores a gitlab access token.",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"username": {
+							Type:        schema.TypeString,
+							Description: "The name of the user that the token belongs.",
+							Computed:    true,
+						},
+						"base_url": {
+							Type:        schema.TypeString,
+							Description: "The base url when connecting to gitlab. Used for gitlab enterprise on-prem.",
+							Computed:    true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -133,6 +152,21 @@ func dataSourceCredentialsRead(ctx context.Context, d *schema.ResourceData, meta
 			})
 		} else {
 			d.Set("github", []interface{}{
+				map[string]interface{}{
+					"username": keys["username"].(string),
+				},
+			})
+		}
+	case "gitlab":
+		if baseUrl, ok := credentials["baseUrl"].(string); ok {
+			d.Set("gitlab", []interface{}{
+				map[string]interface{}{
+					"username": keys["username"].(string),
+					"base_url": baseUrl,
+				},
+			})
+		} else {
+			d.Set("gitlab", []interface{}{
 				map[string]interface{}{
 					"username": keys["username"].(string),
 				},

--- a/internal/provider/data_source_credentials_test.go
+++ b/internal/provider/data_source_credentials_test.go
@@ -111,3 +111,58 @@ data "nftower_credentials" "foo" {
 	workspace_id = nftower_credentials.foo.workspace_id
 }
 `
+
+func TestAccDataSourceCredentialsGitlab(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: template.ParseRandName(testAccDataSourceCredentialsGitlab),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.nftower_credentials.foo", "name", "tf-acceptance-credentials-ds-gitlab"),
+					resource.TestCheckResourceAttr(
+						"data.nftower_credentials.foo", "description", "tf acceptance testing gitlab ds credentials"),
+					resource.TestMatchResourceAttr(
+						"data.nftower_credentials.foo", "date_created", regexp.MustCompile("^[0-9-:TZ]+")),
+					resource.TestMatchResourceAttr(
+						"data.nftower_credentials.foo", "last_updated", regexp.MustCompile("^[0-9-:TZ]+")),
+					resource.TestCheckResourceAttr(
+						"data.nftower_credentials.foo", "gitlab.0.username", "foo"),
+					resource.TestCheckNoResourceAttr(
+						"data.nftower_credentials.foo", "gitlab.0.password"),
+					resource.TestCheckNoResourceAttr(
+						"data.nftower_credentials.foo", "gitlab.0.token"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceCredentialsGitlab = `
+resource "nftower_workspace" "foo" {
+  name        = "tf-acceptance-{{.randName}}"
+  full_name   = "tf acceptance testing ds credentials"
+	
+  description = "Created by the nftower terraform provider acceptance tests. Will be deleted shortly"
+  visibility  = "PRIVATE"
+}
+
+resource "nftower_credentials" "foo" {
+  name        = "tf-acceptance-credentials-ds-gitlab"
+  description = "tf acceptance testing gitlab ds credentials"
+  workspace_id = nftower_workspace.foo.id
+
+  gitlab {
+	username     = "foo"
+	password     = "bar"
+	token        = "baz"
+  }
+}
+
+data "nftower_credentials" "foo" {
+	name = nftower_credentials.foo.name
+	workspace_id = nftower_credentials.foo.workspace_id
+}
+`

--- a/internal/provider/resource_compute_environment_test.go
+++ b/internal/provider/resource_compute_environment_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/healx/terraform-provider-nftower/internal/template"
 )
 
-func TestAccResourceComputeEnvironment(t *testing.T) {
+func TestAccResourceComputeEnvironmentAWS(t *testing.T) {
 	t.Skip("requires real AWS credentials")
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -76,6 +76,124 @@ resource "nftower_compute_environment" "foo" {
 	work_dir      = "s3://somebucket/"
   }
 }
+`
+
+func TestAccResourceComputeEnvironmentLSF(t *testing.T) {
+	t.Skip("requires real ssh login node")
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: "nftower_compute_environment",
+				Config:       template.ParseRandName(testAccResourceComputeEnvironmentLSF),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"nftower_credentials.foo", "name", "tf-acceptance-lsf-ssh-cred"),
+					resource.TestCheckResourceAttr(
+						"nftower_compute_environment.foo", "name", "tf-acceptance-lsf"),
+					resource.TestCheckResourceAttr(
+						"nftower_compute_environment.foo", "lsf_platform.0.work_dir", "/nextflow/work"),
+					resource.TestCheckResourceAttr(
+						"nftower_compute_environment.foo", "lsf_platform.0.launch_dir", "/nextflow/launch"),
+					resource.TestCheckResourceAttr(
+						"nftower_compute_environment.foo", "lsf_platform.0.user_name", "nextflow"),
+					resource.TestCheckResourceAttr(
+						"nftower_compute_environment.foo", "lsf_platform.0.host_name", "localhost"),
+					resource.TestCheckResourceAttr(
+						"nftower_compute_environment.foo", "lsf_platform.0.head_queue", "head"),
+					resource.TestCheckResourceAttr(
+						"nftower_compute_environment.foo", "lsf_platform.0.compute_queue", "compute"),
+					resource.TestCheckResourceAttr(
+						"nftower_compute_environment.foo", "lsf_platform.0.head_job_options", "-x something"),
+					resource.TestMatchResourceAttr(
+						"nftower_compute_environment.foo", "date_created", regexp.MustCompile("^[0-9-:TZ]+")),
+					resource.TestMatchResourceAttr(
+						"nftower_compute_environment.foo", "last_updated", regexp.MustCompile("^[0-9-:TZ]+")),
+					resource.TestMatchResourceAttr(
+						"nftower_compute_environment.foo", "status", regexp.MustCompile("^(CREATING|AVAILABLE|ERRORED)$")),
+				),
+			},
+		},
+	})
+}
+
+const testAccResourceComputeEnvironmentLSF = `
+resource "nftower_workspace" "foo" {
+  name        = "tf-acceptance-{{.randName}}"
+  full_name   = "tf acceptance testing environments"
+
+  description = "Created by the nftower terraform provider acceptance tests. Will be deleted shortly"
+  visibility  = "PRIVATE"
+}
+
+resource "nftower_credentials" "foo" {
+  name        = "tf-acceptance-lsf-ssh-cred"
+  description = "tf acceptance testing lsf environments"
+  workspace_id = nftower_workspace.foo.id
+
+  ssh {
+	private_key = <<EOF
+	-----BEGIN OPENSSH PRIVATE KEY-----
+	b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn
+	NhAAAAAwEAAQAAAYEA1Ui6IQY+FdeCgGPxiK1kz1Smet1uiydviL4pSGzZkJamhIw3Zf/i
+	ccUcH81Oas21fi/sSGKXyMEr1P3qPk3bs25MUpVqS8Mc/2u3grkjL+5BJin5DVpeX+Slzl
+	xyrDTCV0PU+jb0vCGoo1Fuiea5/15IEswfWw+lEjJI05qvYNkX2hQA471FaZmQlbYokStQ
+	OtJaDjLrbxCjNdjTz4vlRzPdpG8jvlSjT4LiP8M9gtPFRPf/MgXXx+fZUx+b/Ki8FeqTP4
+	SbbDhfgtf7Kq5XeFrZOMHa2N7+iaUF3tTV/GNoywLco1sOkpx2pDy8rmoQCJaxcmuUIlji
+	ZxHn3Tu8aNPtAJoWYfPtwPQpyHCcMW72vGNfNmnu4v+jfB6RDZcvThZJOKX0XSrEB+SodS
+	rnBtwNJ1+yhP0wnbJ63fNvetbEq7LstGN2bVi4KWnRaDh07fyCwFL771gRKRK2g+8JhiML
+	AOcqq672WLWZMZ/PRXnpU0HIPF6n7Pz2Yve8n7xnAAAFmP5TY4v+U2OLAAAAB3NzaC1yc2
+	EAAAGBANVIuiEGPhXXgoBj8YitZM9Upnrdbosnb4i+KUhs2ZCWpoSMN2X/4nHFHB/NTmrN
+	tX4v7Ehil8jBK9T96j5N27NuTFKVakvDHP9rt4K5Iy/uQSYp+Q1aXl/kpc5ccqw0wldD1P
+	o29LwhqKNRbonmuf9eSBLMH1sPpRIySNOar2DZF9oUAOO9RWmZkJW2KJErUDrSWg4y628Q
+	ozXY08+L5Ucz3aRvI75Uo0+C4j/DPYLTxUT3/zIF18fn2VMfm/yovBXqkz+Em2w4X4LX+y
+	quV3ha2TjB2tje/omlBd7U1fxjaMsC3KNbDpKcdqQ8vK5qEAiWsXJrlCJY4mcR5907vGjT
+	7QCaFmHz7cD0KchwnDFu9rxjXzZp7uL/o3wekQ2XL04WSTil9F0qxAfkqHUq5wbcDSdfso
+	T9MJ2yet3zb3rWxKuy7LRjdm1YuClp0Wg4dO38gsBS++9YESkStoPvCYYjCwDnKquu9li1
+	mTGfz0V56VNByDxep+z89mL3vJ+8ZwAAAAMBAAEAAAGBAJELsZDt5uEBu71GuqbBjLI3Fj
+	SuTBQUUJSFBhw78kWTPlEb7jzOpRfL/ZFfFPorRUc4ng6oBiM/w2hI+bk/R68hzoPHGw/E
+	8/58KcOb1mMtO18R4k6Da3T5UQ0i79VO1+9ysO8s2ojqtv3CTlM39rvFSWyHJrfNzuuuCL
+	rnEmfhm4fyXJyERiVHiv1VcQcwlpI6JYZMeLICdYwUFg+qStV+XzgJYRx6AMn875J/W2CS
+	VjDOGt3Q/Wr0sGYINBPCR1Ci1yXSaZCHtY0P9yCAh0Elh9htHuOtn6nA3nnhOUyvpVHl0S
+	eQDEQI0jDycgKfsf0chHC5Abmc9rHFcRKEbfggWNjIFwl3S+Q3gCTtIAqTrtwQ2pi0giQR
+	KOc4sT+g6bEmzVsgkEmuSuFAMDyp65Rb1zTB1GgCVCk594k0bRFX4AuA0/fTeSby4enD/Y
+	knjWOEjK87umagvQqfp67Ur5fjQpCszrG9rWHnTTaHbCMzAeWVfplrQ8GLwn+r0GwRYQAA
+	AMEA4YO9tRjgcf3L2rgGSPOLtyCBnoI+3LIPc87n8xYZkEp/HHXH3EnPIqfatZYYv8IYwD
+	UJGCykixuoUpcwHrqQodNLTmm4Q9yf1slBpG08NjXA9ULYy0TZnzxufWSpxnV8JAgAPAJC
+	QXkxqfnWWSNXTa+xhjroBjQoiBjLu1DCCuD26aXdGyZJKmmUIcxCskVHXXvMJw+hbb7/7/
+	hrXpe7fbyDVWnMmkMGZyez7/UMLfyo3UwjiC2uzL+dzu2IQT9jAAAAwQD3igueobM0BH/K
+	KQeJIxIn/K5TWV8XVIGtJzQXvExacS2iZFNP01opyeWYpzmbOpRUzuGJScwsQWWEu/UAYX
+	9nf5aSxjU/XW2OHFEuiL0ha3ccBnGa+encV4CNXdzQdak2rflQr0nBGXou31cj9wRQCXUn
+	tHeBwkupUA+ydCJ5UiNJYii3rRc/urAO18TKTan7bf9eIh8OZTXfvcWw3xNd21FE+XWBqW
+	yimBiwhFmCW5FPZfwZoVku0xjflUzbiZEAAADBANyS83XvnEMzXLun4T37L7UNz3cFooFr
+	OMJpPlPSvJfQdPfKIeHViRyIER5ONRtX8JMWzJPsoVR6M2XtghlAo0cmh7d58UQ717uUiu
+	94mzwJWVyqwRU9/zLJE/HRCvJoWCJUXFMoHnrgPPGdoyylx7F3htOlu4/k3fApdSy/6ZMW
+	DWPlUrsaXhWdBAoEYrv/WlIVef5XnP+sB8nC70hFMwie4YLQlX6vQ4joI/Qr1QEGhfaAc3
+	krNGWJs7lOdXEqdwAAABx0aW1yaWNoYXJkc29uQEdFTC1DSjc0RDJYOU1GAQIDBAU=
+	-----END OPENSSH PRIVATE KEY-----
+	EOF
+  }
+}
+
+resource "nftower_compute_environment" "foo" {
+	name           = "tf-acceptance-lsf"
+	workspace_id   = nftower_workspace.foo.id
+	credentials_id = nftower_credentials.foo.id
+  
+	lsf_platform {
+	  work_dir                 = "/nextflow/work"
+	  launch_dir               = "/nextflow/launch"
+	  user_name                = "nextflow"
+	  host_name                = "example.com"
+	  head_queue               = "head"
+	  compute_queue            = "compute"
+	  head_job_options         = "-x something"
+	  propagate_head_job_options = true
+	  per_job_mem_limit = false
+	  per_task_reserve = false
+	}
+  }
 `
 
 func TestFlattenEnvironmentVariables(t *testing.T) {

--- a/internal/provider/resource_credentials_test.go
+++ b/internal/provider/resource_credentials_test.go
@@ -105,6 +105,141 @@ resource "nftower_credentials" "foo" {
 }
 `
 
+func TestAccResourceCredentialsGitlab(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: "nftower_credentials",
+				Config:       template.ParseRandName(testAccResourceCredentialsGitlab),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"nftower_credentials.foo", "name", "tf-acceptance-credentials-gitlab"),
+					resource.TestCheckResourceAttr(
+						"nftower_credentials.foo", "description", "tf acceptance testing gitlab credentials"),
+					resource.TestMatchResourceAttr(
+						"nftower_credentials.foo", "date_created", regexp.MustCompile("^[0-9-:TZ]+")),
+					resource.TestMatchResourceAttr(
+						"nftower_credentials.foo", "last_updated", regexp.MustCompile("^[0-9-:TZ]+")),
+					resource.TestCheckResourceAttr(
+						"nftower_credentials.foo", "gitlab.0.username", "foo"),
+					resource.TestCheckResourceAttr(
+						"nftower_credentials.foo", "gitlab.0.password", "bar"),
+					resource.TestCheckResourceAttr(
+						"nftower_credentials.foo", "gitlab.0.token", "baz"),
+				),
+			},
+		},
+	})
+}
+
+const testAccResourceCredentialsGitlab = `
+resource "nftower_workspace" "foo" {
+  name        = "tf-acceptance-{{.randName}}"
+  full_name   = "tf acceptance testing credentials"
+	
+  description = "Created by the nftower terraform provider acceptance tests. Will be deleted shortly"
+  visibility  = "PRIVATE"
+}
+
+resource "nftower_credentials" "foo" {
+  name        = "tf-acceptance-credentials-gitlab"
+  description = "tf acceptance testing gitlab credentials"
+  workspace_id = nftower_workspace.foo.id
+
+  gitlab {
+	username     = "foo"
+	password 	 = "bar"
+	token 		 = "baz"
+  }
+}
+`
+
+func TestAccResourceCredentialsSSH(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: "nftower_credentials",
+				Config:       template.ParseRandName(testAccResourceCredentialsSSH),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"nftower_credentials.foo", "name", "tf-acceptance-credentials-ssh"),
+					resource.TestCheckResourceAttr(
+						"nftower_credentials.foo", "description", "tf acceptance testing ssh credentials"),
+					resource.TestMatchResourceAttr(
+						"nftower_credentials.foo", "date_created", regexp.MustCompile("^[0-9-:TZ]+")),
+					resource.TestMatchResourceAttr(
+						"nftower_credentials.foo", "last_updated", regexp.MustCompile("^[0-9-:TZ]+")),
+					resource.TestMatchResourceAttr(
+						"nftower_credentials.foo", "ssh.0.private_key", regexp.MustCompile("BEGIN OPENSSH PRIVATE KEY")),
+				),
+			},
+		},
+	})
+}
+
+const testAccResourceCredentialsSSH = `
+resource "nftower_workspace" "foo" {
+  name        = "tf-acceptance-{{.randName}}"
+  full_name   = "tf acceptance testing credentials"
+	
+  description = "Created by the nftower terraform provider acceptance tests. Will be deleted shortly"
+  visibility  = "PRIVATE"
+}
+
+resource "nftower_credentials" "foo" {
+  name        = "tf-acceptance-credentials-ssh"
+  description = "tf acceptance testing ssh credentials"
+  workspace_id = nftower_workspace.foo.id
+
+  ssh {
+	private_key	 = <<EOF
+	-----BEGIN OPENSSH PRIVATE KEY-----
+	b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn
+	NhAAAAAwEAAQAAAYEA1Ui6IQY+FdeCgGPxiK1kz1Smet1uiydviL4pSGzZkJamhIw3Zf/i
+	ccUcH81Oas21fi/sSGKXyMEr1P3qPk3bs25MUpVqS8Mc/2u3grkjL+5BJin5DVpeX+Slzl
+	xyrDTCV0PU+jb0vCGoo1Fuiea5/15IEswfWw+lEjJI05qvYNkX2hQA471FaZmQlbYokStQ
+	OtJaDjLrbxCjNdjTz4vlRzPdpG8jvlSjT4LiP8M9gtPFRPf/MgXXx+fZUx+b/Ki8FeqTP4
+	SbbDhfgtf7Kq5XeFrZOMHa2N7+iaUF3tTV/GNoywLco1sOkpx2pDy8rmoQCJaxcmuUIlji
+	ZxHn3Tu8aNPtAJoWYfPtwPQpyHCcMW72vGNfNmnu4v+jfB6RDZcvThZJOKX0XSrEB+SodS
+	rnBtwNJ1+yhP0wnbJ63fNvetbEq7LstGN2bVi4KWnRaDh07fyCwFL771gRKRK2g+8JhiML
+	AOcqq672WLWZMZ/PRXnpU0HIPF6n7Pz2Yve8n7xnAAAFmP5TY4v+U2OLAAAAB3NzaC1yc2
+	EAAAGBANVIuiEGPhXXgoBj8YitZM9Upnrdbosnb4i+KUhs2ZCWpoSMN2X/4nHFHB/NTmrN
+	tX4v7Ehil8jBK9T96j5N27NuTFKVakvDHP9rt4K5Iy/uQSYp+Q1aXl/kpc5ccqw0wldD1P
+	o29LwhqKNRbonmuf9eSBLMH1sPpRIySNOar2DZF9oUAOO9RWmZkJW2KJErUDrSWg4y628Q
+	ozXY08+L5Ucz3aRvI75Uo0+C4j/DPYLTxUT3/zIF18fn2VMfm/yovBXqkz+Em2w4X4LX+y
+	quV3ha2TjB2tje/omlBd7U1fxjaMsC3KNbDpKcdqQ8vK5qEAiWsXJrlCJY4mcR5907vGjT
+	7QCaFmHz7cD0KchwnDFu9rxjXzZp7uL/o3wekQ2XL04WSTil9F0qxAfkqHUq5wbcDSdfso
+	T9MJ2yet3zb3rWxKuy7LRjdm1YuClp0Wg4dO38gsBS++9YESkStoPvCYYjCwDnKquu9li1
+	mTGfz0V56VNByDxep+z89mL3vJ+8ZwAAAAMBAAEAAAGBAJELsZDt5uEBu71GuqbBjLI3Fj
+	SuTBQUUJSFBhw78kWTPlEb7jzOpRfL/ZFfFPorRUc4ng6oBiM/w2hI+bk/R68hzoPHGw/E
+	8/58KcOb1mMtO18R4k6Da3T5UQ0i79VO1+9ysO8s2ojqtv3CTlM39rvFSWyHJrfNzuuuCL
+	rnEmfhm4fyXJyERiVHiv1VcQcwlpI6JYZMeLICdYwUFg+qStV+XzgJYRx6AMn875J/W2CS
+	VjDOGt3Q/Wr0sGYINBPCR1Ci1yXSaZCHtY0P9yCAh0Elh9htHuOtn6nA3nnhOUyvpVHl0S
+	eQDEQI0jDycgKfsf0chHC5Abmc9rHFcRKEbfggWNjIFwl3S+Q3gCTtIAqTrtwQ2pi0giQR
+	KOc4sT+g6bEmzVsgkEmuSuFAMDyp65Rb1zTB1GgCVCk594k0bRFX4AuA0/fTeSby4enD/Y
+	knjWOEjK87umagvQqfp67Ur5fjQpCszrG9rWHnTTaHbCMzAeWVfplrQ8GLwn+r0GwRYQAA
+	AMEA4YO9tRjgcf3L2rgGSPOLtyCBnoI+3LIPc87n8xYZkEp/HHXH3EnPIqfatZYYv8IYwD
+	UJGCykixuoUpcwHrqQodNLTmm4Q9yf1slBpG08NjXA9ULYy0TZnzxufWSpxnV8JAgAPAJC
+	QXkxqfnWWSNXTa+xhjroBjQoiBjLu1DCCuD26aXdGyZJKmmUIcxCskVHXXvMJw+hbb7/7/
+	hrXpe7fbyDVWnMmkMGZyez7/UMLfyo3UwjiC2uzL+dzu2IQT9jAAAAwQD3igueobM0BH/K
+	KQeJIxIn/K5TWV8XVIGtJzQXvExacS2iZFNP01opyeWYpzmbOpRUzuGJScwsQWWEu/UAYX
+	9nf5aSxjU/XW2OHFEuiL0ha3ccBnGa+encV4CNXdzQdak2rflQr0nBGXou31cj9wRQCXUn
+	tHeBwkupUA+ydCJ5UiNJYii3rRc/urAO18TKTan7bf9eIh8OZTXfvcWw3xNd21FE+XWBqW
+	yimBiwhFmCW5FPZfwZoVku0xjflUzbiZEAAADBANyS83XvnEMzXLun4T37L7UNz3cFooFr
+	OMJpPlPSvJfQdPfKIeHViRyIER5ONRtX8JMWzJPsoVR6M2XtghlAo0cmh7d58UQ717uUiu
+	94mzwJWVyqwRU9/zLJE/HRCvJoWCJUXFMoHnrgPPGdoyylx7F3htOlu4/k3fApdSy/6ZMW
+	DWPlUrsaXhWdBAoEYrv/WlIVef5XnP+sB8nC70hFMwie4YLQlX6vQ4joI/Qr1QEGhfaAc3
+	krNGWJs7lOdXEqdwAAABx0aW1yaWNoYXJkc29uQEdFTC1DSjc0RDJYOU1GAQIDBAU=
+	-----END OPENSSH PRIVATE KEY-----
+	EOF
+  }
+}
+`
+
 func TestAccResourceCredentials_basic(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },


### PR DESCRIPTION
- added gitlab and ssh credentials
- fixed some bugs with LSFPlatform compute env
- added improved handling of 409 already created for adding members to workspaces
- couple of small fixes to docs

acceptance tests passing: 

```
#( 02/03/24@ 8:39am )( timrichardson@GEL-CJ74D2X9MF ):~/projects/terraform-provider-nftower@bugfix-various✗✗✗
   make                                                                                           
TF_ACC=1 go test ./... -v  -timeout 120m
?   	github.com/healx/terraform-provider-nftower	[no test files]
?   	github.com/healx/terraform-provider-nftower/internal/client	[no test files]
?   	github.com/healx/terraform-provider-nftower/internal/template	[no test files]
=== RUN   TestAccDataSourceCredentialsAWS
--- PASS: TestAccDataSourceCredentialsAWS (2.67s)
=== RUN   TestAccDataSourceCredentialsGithub
--- PASS: TestAccDataSourceCredentialsGithub (2.78s)
=== RUN   TestAccDataSourceCredentialsGitlab
--- PASS: TestAccDataSourceCredentialsGitlab (2.52s)
=== RUN   TestAccDataSourceOrganizationMember
--- PASS: TestAccDataSourceOrganizationMember (2.15s)
=== RUN   TestAccDataSourceWorkspaceParticipant
--- PASS: TestAccDataSourceWorkspaceParticipant (2.36s)
=== RUN   TestAccDataSourceWorkspace
--- PASS: TestAccDataSourceWorkspace (2.22s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestAccResourceComputeEnvironmentAWS
    resource_compute_environment_test.go:15: requires real AWS credentials
--- SKIP: TestAccResourceComputeEnvironmentAWS (0.00s)
=== RUN   TestAccResourceComputeEnvironmentLSF
    resource_compute_environment_test.go:82: requires real ssh login node
--- SKIP: TestAccResourceComputeEnvironmentLSF (0.00s)
=== RUN   TestFlattenEnvironmentVariables
--- PASS: TestFlattenEnvironmentVariables (0.00s)
=== RUN   TestFlattenComputeEnvironmentAWSBatchMinimal
--- PASS: TestFlattenComputeEnvironmentAWSBatchMinimal (0.00s)
=== RUN   TestFlattenComputeEnvironmentAWSBatchComplete
--- PASS: TestFlattenComputeEnvironmentAWSBatchComplete (0.00s)
=== RUN   TestFlattenComputeEnvironmentLSFPlatfromMinimal
--- PASS: TestFlattenComputeEnvironmentLSFPlatfromMinimal (0.00s)
=== RUN   TestFlattenComputeEnvironmentLSFPlatformComplete
--- PASS: TestFlattenComputeEnvironmentLSFPlatformComplete (0.00s)
=== RUN   TestAccResourceCredentialsAWS
--- PASS: TestAccResourceCredentialsAWS (2.22s)
=== RUN   TestAccResourceCredentialsGithub
--- PASS: TestAccResourceCredentialsGithub (2.24s)
=== RUN   TestAccResourceCredentialsGitlab
--- PASS: TestAccResourceCredentialsGitlab (2.27s)
=== RUN   TestAccResourceCredentialsSSH
--- PASS: TestAccResourceCredentialsSSH (2.21s)
=== RUN   TestAccResourceCredentials_basic
--- PASS: TestAccResourceCredentials_basic (2.32s)
=== RUN   TestAccResourceDataset_basic
--- PASS: TestAccResourceDataset_basic (2.02s)
=== RUN   TestAccResourceDatasetVersion_csv
--- PASS: TestAccResourceDatasetVersion_csv (2.32s)
=== RUN   TestAccResourceDatasetVersion_tsv
--- PASS: TestAccResourceDatasetVersion_tsv (2.21s)
=== RUN   TestAccResourceOrganizationMember
--- PASS: TestAccResourceOrganizationMember (1.92s)
=== RUN   TestAccResourceOrganizationMemberOwner
--- PASS: TestAccResourceOrganizationMemberOwner (3.72s)
=== RUN   TestAccResourceOrganizationMemberUpdateRole
--- PASS: TestAccResourceOrganizationMemberUpdateRole (5.41s)
=== RUN   TestAccResourcePipelineSecrets
--- PASS: TestAccResourcePipelineSecrets (2.32s)
=== RUN   TestAccResourceToken
--- PASS: TestAccResourceToken (1.72s)
=== RUN   TestAccResourceWorkspaceParticipant_basic
--- PASS: TestAccResourceWorkspaceParticipant_basic (2.21s)
=== RUN   TestAccResourceWorkspaceParticipant_email
--- PASS: TestAccResourceWorkspaceParticipant_email (2.19s)
=== RUN   TestAccResourceWorkspaceParticipant_maintain
--- PASS: TestAccResourceWorkspaceParticipant_maintain (2.10s)
=== RUN   TestAccResourceWorkspaceParticipant_updateRole
--- PASS: TestAccResourceWorkspaceParticipant_updateRole (4.25s)
=== RUN   TestAccResourceWorkspace
--- PASS: TestAccResourceWorkspace (1.88s)
PASS
ok  	github.com/healx/terraform-provider-nftower/internal/provider	60.672s
```