### PR TITLE
Fixes update container registry credentials

### DIFF
--- a/internal/client/credentials.go
+++ b/internal/client/credentials.go
@@ -215,9 +215,9 @@ func (c *TowerClient) UpdateCredentialsAWS(
 }
 
 func (c *TowerClient) UpdateCredentialsContainerRegistry(
-	ctx context.Context,
-	workspaceId string,
+	ctx context.Context,	
 	id string,
+	workspaceId string,
 	description string,
 	username string,
 	password string,


### PR DESCRIPTION
This fixes the update of container registry credentials. The arguments id and workspaceId were swapped.