### PR TITLE
Update api url to new api.cloud.seqera.io

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -21,7 +21,7 @@ func New(version string) func() *schema.Provider {
 					Optional: true,
 					DefaultFunc: schema.MultiEnvDefaultFunc([]string{
 						"NFTOWER_API_URL",
-					}, "https://api.tower.nf"),
+					}, "https://api.cloud.seqera.io"),
 				},
 				"api_key": {
 					Type:     schema.TypeString,

--- a/internal/provider/resource_dataset_version_test.go
+++ b/internal/provider/resource_dataset_version_test.go
@@ -13,7 +13,7 @@ import (
 func getApiUrl() string {
 	apiUrl := os.Getenv("NFTOWER_API_URL")
 	if apiUrl == "" {
-		apiUrl = "https://api.tower.nf"
+		apiUrl = "https://api.cloud.seqera.io"
 	}
 	apiUrl = strings.TrimRight(apiUrl, "/")
 	return apiUrl


### PR DESCRIPTION
This fixes some of the tests that were failing due to url migration included in the API responses.